### PR TITLE
EntityConfigCommandTest

### DIFF
--- a/Test/Builders/a.php
+++ b/Test/Builders/a.php
@@ -6,6 +6,7 @@ use Drupal\Console\Extension\Manager;
 use Drupal\Console\Generator\AuthenticationProviderGenerator;
 use Drupal\Console\Generator\CommandGenerator;
 use Drupal\Console\Generator\EntityBundleGenerator;
+use Drupal\Console\Generator\EntityConfigGenerator;
 use Drupal\Console\Generator\FormGenerator;
 use Drupal\Console\Generator\ServiceGenerator;
 use Drupal\Console\Utils\ChainQueue;
@@ -34,6 +35,15 @@ class a
     {
         return self::prophet()->prophesize(EntityBundleGenerator::class);
     }
+
+        /**
+         * @return \Prophecy\Prophecy\ObjectProphecy
+         */
+        public static function entityConfigGenerator()
+        {
+            return self::prophet()->prophesize(EntityConfigGenerator::class);
+        }
+
 
     /**
      * @return \Prophecy\Prophecy\ObjectProphecy

--- a/Test/Command/Generate/EntityConfigCommandTest.php
+++ b/Test/Command/Generate/EntityConfigCommandTest.php
@@ -55,7 +55,10 @@ class EntityConfigCommandTest extends GenerateCommandTest
             ],
             ['interactive' => false]
         );
-      
+        $generator
+            ->generate($module, $entity_name, $entity_class, $label, $base_path, $bundle_of=false)
+            ->shouldHaveBeenCalled()
+        ;
         $this->assertEquals(0, $code);
     }
   }

--- a/Test/Command/Generate/EntityConfigCommandTest.php
+++ b/Test/Command/Generate/EntityConfigCommandTest.php
@@ -8,6 +8,9 @@ namespace Drupal\Console\Test\Command\Generate;
 
 use Drupal\Console\Command\Generate\EntityConfigCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use Drupal\Console\Utils\StringConverter;
+use Drupal\Console\Test\Builders\a as an;
+use Drupal\Console\Utils\Validator;
 use Drupal\Console\Test\DataProvider\EntityConfigDataProviderTrait;
 
 class EntityConfigCommandTest extends GenerateCommandTest
@@ -32,10 +35,14 @@ class EntityConfigCommandTest extends GenerateCommandTest
         $label,
         $base_path
     ) {
-        $command = new EntityConfigCommand($this->getHelperSet());
-        $command->setHelperSet($this->getHelperSet());
-        $command->setGenerator($this->getGenerator());
-
+        $generator = an::entityConfigGenerator();
+        $manager = an::extensionManager();
+        $command = new EntityConfigCommand(
+          $manager,
+          $generator->reveal(),
+          new Validator($manager),
+          new StringConverter()
+        );
         $commandTester = new CommandTester($command);
 
         $code = $commandTester->execute(
@@ -48,16 +55,7 @@ class EntityConfigCommandTest extends GenerateCommandTest
             ],
             ['interactive' => false]
         );
-
+      
         $this->assertEquals(0, $code);
     }
-
-    private function getGenerator()
-    {
-        return $this
-            ->getMockBuilder('Drupal\Console\Generator\EntityConfigGenerator')
-            ->disableOriginalConstructor()
-            ->setMethods(['generate'])
-            ->getMock();
-    }
-}
+  }

--- a/Test/Command/Generate/GenerateCommandTest.php
+++ b/Test/Command/Generate/GenerateCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\Console\Test\Command\Generate;
+
+use Symfony\Component\DependencyInjection\Container;
+use Drupal\Console\Test\BaseTestCase;
+
+abstract class GenerateCommandTest extends BaseTestCase
+{
+    /**
+     * @return \Symfony\Component\DependencyInjection\ContainerInterface Drupal container
+     */
+    protected function getContainer()
+    {
+        $container = new Container();
+        $container->set('twig', new \Twig_Environment());
+        return $container;
+    }
+}


### PR DESCRIPTION
In the class EntityConfigCommand the bundle_of is set as a null in the
configure function, so to make the test run bundle_of is assigned as a
new parameter equals to false.